### PR TITLE
Fixed non english os bug

### DIFF
--- a/source/port-killer.ts
+++ b/source/port-killer.ts
@@ -61,7 +61,7 @@ export class Killer {
                 resolver = resolve
             })
 
-        const findstr = spawn('findstr', [`:${port}.*LISTENING`], {
+        const findstr = spawn('findstr', [`:${port}.*`], {
             stdio: ['pipe'],
         })
         const netstat = spawn('netstat', ['-ano'], {


### PR DESCRIPTION
Windows translates the status in the `netstat -ano` command.
This makes it unable to find the pid(s) for the port.